### PR TITLE
fix #4

### DIFF
--- a/alco/collector/models.py
+++ b/alco/collector/models.py
@@ -37,6 +37,11 @@ class LoggerIndex(models.Model):
         return list(self.loggercolumn_set.filter(
             filtered=True).values_list('name', flat=True))
 
+    @property
+    def visible_fields(self):
+        return list(self.loggercolumn_set.filter(
+            display=True).values_list('name', flat=True))
+
     def __str__(self):
         return self.name
 

--- a/alco/grep/api/filters.py
+++ b/alco/grep/api/filters.py
@@ -85,11 +85,11 @@ class JSONFieldFilter(BaseFilterBackend):
                     numeric.append(int(v))
                 except ValueError:
                     continue
-            stub = ','.join(['%s' * len(values)])
+            stub = ', '.join(['%s'] * len(values))
             extra_lookups['__%s_str' % lookup] = 'IN(js.%s, %s)' % (field, stub)
             extra_params.extend(values)
             if numeric:
-                stub = ','.join(['%s' * len(numeric)])
+                stub = ', '.join(['%s'] * len(numeric))
                 extra_lookups['__%s_int' % lookup] = 'IN(js.%s, %s)' % (field,
                                                                         stub)
                 extra_params.extend(numeric)
@@ -109,7 +109,9 @@ class JSONFieldFilter(BaseFilterBackend):
         for key in json_fields:
             value = request.query_params.get(key + '__in')
             if value is None:
-                continue
+                value = request.query_params.get(key)
+                if value is None:
+                    continue
             lookups[key + '__in'] = value.split(',')
 
         return lookups

--- a/alco/grep/api/views.py
+++ b/alco/grep/api/views.py
@@ -30,7 +30,7 @@ class GrepView(ListAPIView):
 
             class Meta:
                 model = self.log_model
-                fields = ['ts'] + self.index.field_names
+                fields = ['ts']
 
         return TimestampFilter
 
@@ -61,7 +61,7 @@ class GrepView(ListAPIView):
         return self.log_model.objects.order_by('ts', 'ms', 'seq')
 
     def get_json_fields(self, request):
-        fields = self.index.filtered_fields
+        fields = self.index.visible_fields
         result = []
         for key, value in request.GET.items():
             field = key.split('__')[0]


### PR DESCRIPTION
Now js fields are filtered not only against str value, but also against int value if possible.

I.e. for request 

```
/grep/logger/?process=123
```

SQL where part is:

```
WHERE js.process = 123 OR js.process = '123'
```
